### PR TITLE
dotnet core 2 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q && apt-get install -y apt-t
 RUN pip install awscli==1.11.131
 
 # dotnet toolstack for building/testing
-RUN sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ xenial main" > /etc/apt/sources.list.d/dotnetdev.list' && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 417A0893 && apt update && apt install -y dotnet-dev-1.0.4
+RUN curl -o packages-microsoft-prod.deb https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb
+RUN dpkg -i packages-microsoft-prod.deb
+RUN apt update
+RUN apt install -y dotnet-sdk-2.1.4
 
 WORKDIR /var/app


### PR DESCRIPTION
A few projects have been using this Docker build for .NET Core 2 support, cleaner to have it available as an image